### PR TITLE
fix: Duplicate harvester name check on edit

### DIFF
--- a/src/main/java/swg/gui/resources/SWGHarvesterDialog.java
+++ b/src/main/java/swg/gui/resources/SWGHarvesterDialog.java
@@ -244,8 +244,9 @@ final class SWGHarvesterDialog extends SWGJDialog implements ActionListener {
             } else if (name.getText().length() < 3) {
                 msg = "Enter a description, 3 letters or more";
                 ttl = "Invalid description";
-            } else if (SWGResController.harvestersExists(
-                    name.getText(), SWGResourceTab.galaxy())) {
+            } else if ((currentHarvester == null || clone.isSelected()) 
+                      && SWGResController.harvestersExists(
+                         name.getText(), SWGResourceTab.galaxy())) {
                 msg = "A harvester with this name exists";
                 ttl = "Name conflict";
             } else if (b <= 0) {

--- a/src/main/java/swg/gui/resources/SWGHarvesterDialog.java
+++ b/src/main/java/swg/gui/resources/SWGHarvesterDialog.java
@@ -244,9 +244,10 @@ final class SWGHarvesterDialog extends SWGJDialog implements ActionListener {
             } else if (name.getText().length() < 3) {
                 msg = "Enter a description, 3 letters or more";
                 ttl = "Invalid description";
-            } else if ((currentHarvester == null || clone.isSelected()) 
-                      && SWGResController.harvestersExists(
-                         name.getText(), SWGResourceTab.galaxy())) {
+            } else if ((currentHarvester == null                                         // new harvester
+                        || clone.isSelected()                                            // clone harvester
+                        || !currentHarvester.getName().equalsIgnoreCase(name.getText())) // edit description
+                      && SWGResController.harvestersExists(name.getText(), SWGResourceTab.galaxy())) {
                 msg = "A harvester with this name exists";
                 ttl = "Name conflict";
             } else if (b <= 0) {


### PR DESCRIPTION
This fixes an issue discovered by a discord user. The OK button checks for duplicate harvester names even in edit mode. We need to use similar logic to `saveHarvester` where it checks for editing a harvester or the clone checkbox.

![image](https://github.com/user-attachments/assets/55110f7b-4095-4e33-8109-446699b01e1d)

![image](https://github.com/user-attachments/assets/0b9a2a7f-081b-4da7-a3d2-31314e968b47)

![image](https://github.com/user-attachments/assets/ed747e06-9405-4dc9-953a-9929f71520b2)
